### PR TITLE
Remove redundant symfony/polyfill-php80 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "symfony/dotenv": "^6.0",
         "symfony/http-foundation": "^6.0",
         "symfony/polyfill-php74": "^1.24",
-        "symfony/polyfill-php80": "^1.24",
         "symfony/yaml": "^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
This package depends on `symfony/polyfill-php80`, but also `php: ^8.1`, so the polyfill requirement doesn't seem necessary anymore?